### PR TITLE
add recovery page for backup url

### DIFF
--- a/app/recover/page.tsx
+++ b/app/recover/page.tsx
@@ -1,39 +1,7 @@
 "use client";
 
-import { useEffect } from "react";
-import { useRouter, useParams } from "next/navigation";
-import { Sigmoji, deserializeSigmoji } from "@/lib/types";
-import { updateSigmojiList } from "@/lib/localStorage";
+import RecoverScreen from "@/components/screens/RecoverScreen";
 
 export default function RecoverPage() {
-  const router = useRouter();
-  const params = useParams();
-
-  useEffect(() => {
-    const recoverBackup = async () => {
-      if (typeof window !== "undefined") {
-        const urlParams = new URLSearchParams(location.search);
-        const sigmojis = await getCollectionFromParams(urlParams);
-        await updateSigmojiList(sigmojis);
-        router.push("/home");
-      }
-    };
-    recoverBackup();
-  }, [params, router]);
-
-  return <></>;
-}
-
-function getCollectionFromParams(params: URLSearchParams): Promise<Sigmoji[]> {
-  const collection = params.get("collection");
-  if (!collection) {
-    return Promise.resolve([]);
-  }
-
-  const serializedSigmojis = JSON.parse(collection);
-  if (!Array.isArray(serializedSigmojis)) {
-    return Promise.resolve([]);
-  }
-
-  return Promise.all(serializedSigmojis.map(deserializeSigmoji));
+  return <RecoverScreen />;
 }

--- a/app/recover/page.tsx
+++ b/app/recover/page.tsx
@@ -1,7 +1,39 @@
 "use client";
 
-import HomeScreen from "@/components/screens/HomeScreen";
+import { useEffect } from "react";
+import { useRouter, useParams } from "next/navigation";
+import { Sigmoji, deserializeSigmoji } from "@/lib/types";
+import { updateSigmojiList } from "@/lib/localStorage";
 
-export default function Home() {
-  return <HomeScreen />;
+export default function RecoverPage() {
+  const router = useRouter();
+  const params = useParams();
+
+  useEffect(() => {
+    const recoverBackup = async () => {
+      if (typeof window !== "undefined") {
+        const urlParams = new URLSearchParams(location.search);
+        const sigmojis = await getCollectionFromParams(urlParams);
+        await updateSigmojiList(sigmojis);
+        router.push("/home");
+      }
+    };
+    recoverBackup();
+  }, [params, router]);
+
+  return <></>;
+}
+
+function getCollectionFromParams(params: URLSearchParams): Promise<Sigmoji[]> {
+  const collection = params.get("collection");
+  if (!collection) {
+    return Promise.resolve([]);
+  }
+
+  const serializedSigmojis = JSON.parse(collection);
+  if (!Array.isArray(serializedSigmojis)) {
+    return Promise.resolve([]);
+  }
+
+  return Promise.all(serializedSigmojis.map(deserializeSigmoji));
 }

--- a/components/screens/RecoverScreen.tsx
+++ b/components/screens/RecoverScreen.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import styled from "styled-components";
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Sigmoji, deserializeSigmoji } from "@/lib/types";
+import { updateSigmojiList } from "@/lib/localStorage";
+import { MainHeader } from "@/components/shared/Headers";
+import Footer from "@/components/shared/Footer";
+import { CourierPrimeBase } from "@/components/core";
+
+enum RecoverState {
+  RECOVERING,
+  RECOVERED,
+  ERROR,
+}
+
+export default function RecoverScreen() {
+  const [recoverState, setRecoverState] = useState<RecoverState>(
+    RecoverState.RECOVERING
+  );
+  const [recoveryString, setRecoveryString] = useState<string>();
+  const router = useRouter();
+
+  useEffect(() => {
+    const recoverBackup = async () => {
+      if (typeof window === "undefined") {
+        return;
+      }
+
+      // Prevents rerunning of effect
+      if (recoveryString === location.search) {
+        return;
+      }
+      setRecoveryString(location.search);
+
+      try {
+        const urlParams = new URLSearchParams(location.search);
+        const sigmojis = await getCollectionFromParams(urlParams);
+        await updateSigmojiList(sigmojis);
+        setRecoverState(RecoverState.RECOVERED);
+        alert(`Successfully recovered ${sigmojis.length} sigmojis!`);
+        router.push("/home");
+      } catch (err) {
+        console.error(err);
+        setRecoverState(RecoverState.ERROR);
+      }
+    };
+    recoverBackup();
+  }, [router, recoveryString]);
+
+  const getRecoverText = () => {
+    switch (recoverState) {
+      case RecoverState.RECOVERING:
+        return "Recovering your collection...";
+      case RecoverState.RECOVERED:
+        return "Successfully recovered your collection!";
+      case RecoverState.ERROR:
+        return "Error recovering your collection. Please try again.";
+    }
+  };
+
+  return (
+    <div className="flex flex-col min-h-screen">
+      <MainHeader />
+      <RecoverContainer>
+        <CourierPrimeBase>{getRecoverText()}</CourierPrimeBase>
+      </RecoverContainer>
+      <div style={{ marginTop: "auto" }}>
+        <Footer />
+      </div>
+    </div>
+  );
+}
+
+function getCollectionFromParams(params: URLSearchParams): Promise<Sigmoji[]> {
+  const collection = params.get("collection");
+  if (!collection) {
+    throw new Error("No collection found in URL params");
+  }
+
+  const serializedSigmojis = JSON.parse(collection);
+  if (!Array.isArray(serializedSigmojis)) {
+    throw new Error("Collection in URL params is not an array");
+  }
+
+  return Promise.all(serializedSigmojis.map(deserializeSigmoji));
+}
+
+const RecoverContainer = styled.div`
+  display: flex;
+  gap: 16px;
+  padding: 16px;
+  flex-direction: column;
+  text-align: center;
+  align-items: center;
+  align-self: stretch;
+`;

--- a/lib/localStorage.ts
+++ b/lib/localStorage.ts
@@ -85,7 +85,23 @@ export async function updateSigmoji(sigmoji: Sigmoji): Promise<void> {
   if (index !== -1) {
     sigmojis[index] = sigmoji;
   }
+
   serializeSigmojisInLocalStorage(sigmojis);
+}
+
+/*
+ * Updates the sigmojis in local storage with a new list.
+ * Will overwrite any sigmojis that have the same emojiImg with the new list.
+ * @param newSigmojis - The new list of sigmojis to update with.
+ */
+export async function updateSigmojiList(newSigmojis: Sigmoji[]): Promise<void> {
+  const currentSigmojis = await loadSigmojis();
+  const newSigmojiKeys = newSigmojis.map((s) => s.emojiImg);
+  const updatedSigmojis = newSigmojis.concat(
+    currentSigmojis.filter((s) => !newSigmojiKeys.includes(s.emojiImg))
+  );
+
+  serializeSigmojisInLocalStorage(updatedSigmojis);
 }
 
 /**


### PR DESCRIPTION
Implements /recover, a page for recovering a Sigmoji collection based on a backup url. Parses the collection from the url and merges it into a user's existing Sigmojis. 