### PR TITLE
add chat for cardholders

### DIFF
--- a/app/anon/page.tsx
+++ b/app/anon/page.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import AnonChatScreen from "@/components/screens/AnonChatScreen";
+
+export default function Home() {
+  return <AnonChatScreen />;
+}

--- a/app/api/anon/route.ts
+++ b/app/api/anon/route.ts
@@ -1,60 +1,17 @@
 import { NextResponse } from "next/server";
 import { MembershipVerifier } from "@personaelabs/spartan-ecdsa";
-import prisma from "@/lib/prisma";
 import { Telegraf } from "telegraf";
 import path from "path";
 
 const telegramBot = new Telegraf(process.env.TELEGRAM_BOT_TOKEN!);
 const TELEGRAM_TEST_CHAT_ID = -4031859798;
-const emojiMap: { [key: string]: string } = {
-  "robot.png": "🤖",
-  "invader.png": "👾",
-  "ninja.png": "🥷",
-  "turtle.png": "🐢",
-  "pizza.png": "🍕",
-  "pinata.png": "🪅",
-  "unicorn.png": "🦄",
-  "mushroom.png": "🍄",
-  "soccer.png": "⚽️",
-  "pumpkin.png": "🎃",
-  "avocado.png": "🥑",
-  "nerd.png": "🤓",
-  "ghost.png": "👻",
-  "cowboy.png": "🤠",
-  "alien.png": "👽",
-  "icecream.png": "🍦",
-  "fairy.png": "🧚",
-  "butterfly.png": "🦋",
-  "bubbles.png": "🧼",
-  "dolphin.png": "🐬",
-  "angry-cat.png": "😾",
-  "baby-angel.png": "👼",
-  "blue-swirl.png": "🌀",
-  "boba.png": "🧋",
-  "caterpillar.png": "🐛",
-  "clown.png": "🤡",
-  "cookie.png": "🍪",
-  "crystal-ball.png": "🔮",
-  "dumpling.png": "🥟",
-  "eyes.png": "👀",
-  "fingers-crossed.png": "🤞",
-  "handshake.png": "🤝",
-  "head-exploding.png": "🤯",
-  "lollipop.png": "🍭",
-  "magic-wand.png": "🪄",
-  "palette.png": "🎨",
-  "poop.png": "💩",
-  "skull.png": "💀",
-  "sloth.png": "🦥",
-  "squirrel.png": "🐿",
-};
 
 /**
- * POST /api/telegram
+ * POST /api/anon
  * Posts a pseudonymous chat message which is verified and broadcasted to the Telegram chat bot.
  * @param {object} request - The request object. Consists of the following parameters encoded as JSON.
+ * @param {string} request.pseudonym - The pseudonym the user is posting as.
  * @param {string} request.message - The message the user is posting.
- * @param {string} request.sigmoji - The Sigmoji the user is posting as. Currently represents the emojiImg of the Sigmoji.
  * @param {string} request.serializedZKP - The serialized zero-knowledge proof provided by the user.
  * @returns A JSON response with a success boolean indicating if the chat message was posted.
  */
@@ -62,7 +19,7 @@ export async function POST(request: Request) {
   try {
     const bodyArrayBuffer = await request.arrayBuffer();
     const bodyString = new TextDecoder().decode(bodyArrayBuffer);
-    const { message, sigmoji, serializedZKP } = JSON.parse(bodyString);
+    const { pseudonym, message, serializedZKP } = JSON.parse(bodyString);
 
     // can't use deserializeSigmojiZKP due to some Next.js problem
     const parsedZKP = JSON.parse(serializedZKP);
@@ -76,15 +33,8 @@ export async function POST(request: Request) {
       throw new Error("Proof failed verification");
     }
 
-    if (!emojiMap.hasOwnProperty(sigmoji)) {
-      throw new Error("Sigmoji not found");
-    }
-
-    const emoji = emojiMap[sigmoji];
-    const fullMessage = `${emoji}: ${message}`;
+    const fullMessage = `A Sigmoji holder (${pseudonym}): ${message}`;
     telegramBot.telegram.sendMessage(TELEGRAM_TEST_CHAT_ID, fullMessage);
-
-    await addChatLog({ message, sigmoji });
 
     return new NextResponse(undefined, {
       status: 200,
@@ -120,21 +70,4 @@ async function verifyProof(zkp: {
   await verifier.initWasm();
 
   return await verifier.verify(zkp.proof, zkp.publicInputSer);
-}
-
-/**
- * Adds a new entry to the chat log.
- * @param logEntry - The entry to add.
- * @param logEntry.message - The message that was sent.
- * @param logEntry.sigmoji - The Sigmoji the user is posting as. Currently represents the emojiImg of the Sigmoji.
- */
-async function addChatLog(logEntry: { message: string; sigmoji: string }) {
-  try {
-    const newEntry = await prisma.chatLog.create({
-      data: logEntry,
-    });
-    console.log("New chat log entry:", newEntry);
-  } catch (error) {
-    console.error("Error adding chat log entry:", error);
-  }
 }

--- a/app/api/cardholder/route.ts
+++ b/app/api/cardholder/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { Telegraf } from "telegraf";
 import { cardPubKeys } from "@/lib/cardPubKeys";
-import SigningKey from "@ethersproject/signing-key";
+import { recoverPublicKey } from "ethers/lib/utils";
 import { hashMessage } from "@/lib/signatureUtils";
 
 const telegramBot = new Telegraf(process.env.TELEGRAM_BOT_TOKEN!);
@@ -49,7 +49,7 @@ export async function POST(request: Request) {
     const messageHash = hashMessage(message);
 
     const sig = `0x${signature.r}${signature.s}${signature.v.toString(16)}`;
-    const publicKey = SigningKey.recoverPublicKey(messageHash, sig);
+    const publicKey = recoverPublicKey(messageHash, sig);
     console.log("Recovering public key: ", publicKey);
     if (!publicKey) {
       throw new Error("Could not recover public key from signature.");
@@ -86,7 +86,7 @@ export async function POST(request: Request) {
  */
 function getSigmojiFromPublicKey(publicKey: string): string | undefined {
   for (const cardPubKey of Object.values(cardPubKeys)) {
-    if (cardPubKey.secondaryPublicKeyRaw === publicKey) {
+    if (cardPubKey.primaryPublicKeyRaw === publicKey) {
       return cardPubKey.image;
     }
   }

--- a/app/api/cardholder/route.ts
+++ b/app/api/cardholder/route.ts
@@ -1,0 +1,93 @@
+import { NextResponse } from "next/server";
+import prisma from "@/lib/prisma";
+import { Telegraf } from "telegraf";
+import { ethers } from "ethers";
+import { cardPubKeys } from "@/lib/cardPubKeys";
+
+const telegramBot = new Telegraf(process.env.TELEGRAM_BOT_TOKEN!);
+const TELEGRAM_TEST_CHAT_ID = -4031859798;
+const emojiMap: { [key: string]: string } = {
+  "robot.png": "🤖",
+  "invader.png": "👾",
+  "ninja.png": "🥷",
+  "turtle.png": "🐢",
+  "pizza.png": "🍕",
+  "pinata.png": "🪅",
+  "unicorn.png": "🦄",
+  "mushroom.png": "🍄",
+  "soccer.png": "⚽️",
+  "pumpkin.png": "🎃",
+  "avocado.png": "🥑",
+  "nerd.png": "🤓",
+  "ghost.png": "👻",
+  "cowboy.png": "🤠",
+  "alien.png": "👽",
+  "icecream.png": "🍦",
+  "fairy.png": "🧚",
+  "butterfly.png": "🦋",
+  "bubbles.png": "🫧",
+  "dolphin.png": "🐬",
+};
+
+/**
+ * POST /api/cardholder
+ * Posts a pseudonymous chat message which is verified and broadcasted to the Telegram chat bot.
+ * @param {object} request - The request object. Consists of the following parameters encoded as JSON.
+ * @param {string} request.message - The message the user is posting.
+ * @param {string} request.signature - The signature of the message.
+ * @param {string} request.signature.r - The r value of the signature.
+ * @param {string} request.signature.s - The s value of the signature.
+ * @param {string} request.signature.v - The v value of the signature.
+ * @returns A JSON response with a success boolean indicating if the chat message was posted.
+ */
+export async function POST(request: Request) {
+  try {
+    const bodyArrayBuffer = await request.arrayBuffer();
+    const bodyString = new TextDecoder().decode(bodyArrayBuffer);
+    const { message, signature } = JSON.parse(bodyString);
+
+    const sig = `0x${signature.r}${signature.s}${signature.v.toString(16)}`;
+    const publicKey = ethers.verifyMessage(message, sig);
+    console.log("Recovering public key: ", publicKey);
+    if (!publicKey) {
+      throw new Error("Could not recover public key from signature.");
+    }
+
+    const sigmoji = getSigmojiFromPublicKey(publicKey);
+    console.log("Sigmoji: ", sigmoji);
+    if (!sigmoji) {
+      throw new Error("Signature does not correspond to any card.");
+    }
+
+    const emoji = emojiMap[sigmoji];
+    const fullMessage = `Cardholder of ${emoji}: ${message}`;
+    telegramBot.telegram.sendMessage(TELEGRAM_TEST_CHAT_ID, fullMessage);
+
+    return new NextResponse(undefined, {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  } catch (error) {
+    console.error(error);
+    return new NextResponse(JSON.stringify({ error }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+}
+
+/**
+ * Gets the Sigmoji corresponding to a public key. Returns undefined if the public key is not found.
+ * Currently returns the Sigmoji's emojiImg.
+ * @param publicKey - The public key to get the Sigmoji for.
+ * @returns The emojiImg corresponding to the public key or undefined if the public key is not found.
+ */
+function getSigmojiFromPublicKey(publicKey: string): string | undefined {
+  for (const cardPubKey of Object.values(cardPubKeys)) {
+    if (cardPubKey.secondaryPublicKeyRaw === publicKey) {
+      return cardPubKey.image;
+    }
+  }
+
+  return;
+}

--- a/app/api/cardholder/route.ts
+++ b/app/api/cardholder/route.ts
@@ -50,13 +50,12 @@ export async function POST(request: Request) {
 
     const sig = `0x${signature.r}${signature.s}${signature.v.toString(16)}`;
     const publicKey = recoverPublicKey(messageHash, sig);
-    console.log("Recovering public key: ", publicKey);
     if (!publicKey) {
       throw new Error("Could not recover public key from signature.");
     }
 
-    const sigmoji = getSigmojiFromPublicKey(publicKey);
-    console.log("Sigmoji: ", sigmoji);
+    // Remove the 0x prefix from the public key
+    const sigmoji = getSigmojiFromPublicKey(publicKey.slice(2));
     if (!sigmoji) {
       throw new Error("Signature does not correspond to any card.");
     }

--- a/app/api/cardholder/route.ts
+++ b/app/api/cardholder/route.ts
@@ -1,5 +1,4 @@
 import { NextResponse } from "next/server";
-import prisma from "@/lib/prisma";
 import { Telegraf } from "telegraf";
 import { cardPubKeys } from "@/lib/cardPubKeys";
 import { recoverPublicKey } from "ethers/lib/utils";
@@ -26,8 +25,28 @@ const emojiMap: { [key: string]: string } = {
   "icecream.png": "🍦",
   "fairy.png": "🧚",
   "butterfly.png": "🦋",
-  "bubbles.png": "🫧",
+  "bubbles.png": "🧼",
   "dolphin.png": "🐬",
+  "angry-cat.png": "😾",
+  "baby-angel.png": "👼",
+  "blue-swirl.png": "🌀",
+  "boba.png": "🧋",
+  "caterpillar.png": "🐛",
+  "clown.png": "🤡",
+  "cookie.png": "🍪",
+  "crystal-ball.png": "🔮",
+  "dumpling.png": "🥟",
+  "eyes.png": "👀",
+  "fingers-crossed.png": "🤞",
+  "handshake.png": "🤝",
+  "head-exploding.png": "🤯",
+  "lollipop.png": "🍭",
+  "magic-wand.png": "🪄",
+  "palette.png": "🎨",
+  "poop.png": "💩",
+  "skull.png": "💀",
+  "sloth.png": "🦥",
+  "squirrel.png": "🐿",
 };
 
 /**

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,0 +1,140 @@
+import { NextResponse } from "next/server";
+import { MembershipVerifier } from "@personaelabs/spartan-ecdsa";
+import prisma from "@/lib/prisma";
+import { Telegraf } from "telegraf";
+import path from "path";
+
+const telegramBot = new Telegraf(process.env.TELEGRAM_BOT_TOKEN!);
+const TELEGRAM_TEST_CHAT_ID = -4031859798;
+const emojiMap: { [key: string]: string } = {
+  "robot.png": "🤖",
+  "invader.png": "👾",
+  "ninja.png": "🥷",
+  "turtle.png": "🐢",
+  "pizza.png": "🍕",
+  "pinata.png": "🪅",
+  "unicorn.png": "🦄",
+  "mushroom.png": "🍄",
+  "soccer.png": "⚽️",
+  "pumpkin.png": "🎃",
+  "avocado.png": "🥑",
+  "nerd.png": "🤓",
+  "ghost.png": "👻",
+  "cowboy.png": "🤠",
+  "alien.png": "👽",
+  "icecream.png": "🍦",
+  "fairy.png": "🧚",
+  "butterfly.png": "🦋",
+  "bubbles.png": "🧼",
+  "dolphin.png": "🐬",
+  "angry-cat.png": "😾",
+  "baby-angel.png": "👼",
+  "blue-swirl.png": "🌀",
+  "boba.png": "🧋",
+  "caterpillar.png": "🐛",
+  "clown.png": "🤡",
+  "cookie.png": "🍪",
+  "crystal-ball.png": "🔮",
+  "dumpling.png": "🥟",
+  "eyes.png": "👀",
+  "fingers-crossed.png": "🤞",
+  "handshake.png": "🤝",
+  "head-exploding.png": "🤯",
+  "lollipop.png": "🍭",
+  "magic-wand.png": "🪄",
+  "palette.png": "🎨",
+  "poop.png": "💩",
+  "skull.png": "💀",
+  "sloth.png": "🦥",
+  "squirrel.png": "🐿",
+};
+
+/**
+ * POST /api/chat
+ * Posts a pseudonymous chat message which is verified and broadcasted to the Telegram chat bot.
+ * @param {object} request - The request object. Consists of the following parameters encoded as JSON.
+ * @param {string} request.message - The message the user is posting.
+ * @param {string} request.sigmoji - The Sigmoji the user is posting as. Currently represents the emojiImg of the Sigmoji.
+ * @param {string} request.serializedZKP - The serialized zero-knowledge proof provided by the user.
+ * @returns A JSON response with a success boolean indicating if the chat message was posted.
+ */
+export async function POST(request: Request) {
+  try {
+    const bodyArrayBuffer = await request.arrayBuffer();
+    const bodyString = new TextDecoder().decode(bodyArrayBuffer);
+    const { message, sigmoji, serializedZKP } = JSON.parse(bodyString);
+
+    // can't use deserializeSigmojiZKP due to some Next.js problem
+    const parsedZKP = JSON.parse(serializedZKP);
+    const zkp = {
+      proof: new Uint8Array(parsedZKP.proof),
+      publicInputSer: new Uint8Array(parsedZKP.publicInput),
+    };
+
+    const verified = await verifyProof(zkp);
+    if (!verified) {
+      throw new Error("Proof failed verification");
+    }
+
+    if (!emojiMap.hasOwnProperty(sigmoji)) {
+      throw new Error("Sigmoji not found");
+    }
+
+    const emoji = emojiMap[sigmoji];
+    const fullMessage = `${emoji}: ${message}`;
+    telegramBot.telegram.sendMessage(TELEGRAM_TEST_CHAT_ID, fullMessage);
+
+    await addChatLog({ message, sigmoji });
+
+    return new NextResponse(undefined, {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  } catch (error) {
+    console.error(error);
+    return new NextResponse(JSON.stringify({ error }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+}
+
+/**
+ * Verifies an array of proofs.
+ * @param zkp - A proof to verify
+ * @param zkp.proof - The proof contents as a Uint8Array.
+ * @param zkp.publicInputSer - The serialized public input of the proof.
+ * @returns A promise that resolves to a boolean indicating whether the proof was verified.
+ */
+async function verifyProof(zkp: {
+  proof: Uint8Array;
+  publicInputSer: Uint8Array;
+}): Promise<boolean> {
+  const verifier = new MembershipVerifier({
+    circuit: path.resolve(
+      process.cwd(),
+      "./app/api/leaderboard/pubkey_membership.circuit"
+    ),
+    enableProfiler: true,
+  });
+  await verifier.initWasm();
+
+  return await verifier.verify(zkp.proof, zkp.publicInputSer);
+}
+
+/**
+ * Adds a new entry to the chat log.
+ * @param logEntry - The entry to add.
+ * @param logEntry.message - The message that was sent.
+ * @param logEntry.sigmoji - The Sigmoji the user is posting as. Currently represents the emojiImg of the Sigmoji.
+ */
+async function addChatLog(logEntry: { message: string; sigmoji: string }) {
+  try {
+    const newEntry = await prisma.chatLog.create({
+      data: logEntry,
+    });
+    console.log("New chat log entry:", newEntry);
+  } catch (error) {
+    console.error("Error adding chat log entry:", error);
+  }
+}

--- a/app/cardholder/page.tsx
+++ b/app/cardholder/page.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import CardholderScreen from "@/components/screens/CardholderScreen";
+
+export default function Home() {
+  return <CardholderScreen />;
+}

--- a/components/modals/CardholderTapModal.tsx
+++ b/components/modals/CardholderTapModal.tsx
@@ -24,7 +24,7 @@ export default function CardholderTapModal({
       const messageHash = hashMessage(message);
       let command = {
         name: "sign",
-        keyNo: 2,
+        keyNo: 1,
         digest: Buffer.from(messageHash).toString("hex"),
       };
 

--- a/components/modals/CardholderTapModal.tsx
+++ b/components/modals/CardholderTapModal.tsx
@@ -56,7 +56,7 @@ export default function CardholderTapModal({
           rawSignature: res.signature.raw,
           publicKey: res.publicKey,
         });
-        console.log("Tapped card: ", res);
+        console.log("Tapped card with public key: ", res.publicKey);
         setStatusText("Tapped card! Process result...");
       } catch (error) {
         console.error(error);

--- a/components/modals/CardholderTapModal.tsx
+++ b/components/modals/CardholderTapModal.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { OuterContainer, InnerContainer } from "../shared/Modal";
+import Modal from "./Modal";
+import { PrimaryFontBase, PrimaryFontH3 } from "../core";
+import { execHaloCmdWeb } from "@arx-research/libhalo/api/web.js";
+import { useEffect, useState } from "react";
+import { SignMessageArgs } from "../screens/CardholderScreen";
+import { hashMessage } from "@/lib/signatureUtils";
+
+export type CardholderTapModalProps = {
+  message: string;
+  onTap: (args: SignMessageArgs) => Promise<void>;
+};
+
+export default function CardholderTapModal({
+  message,
+  onTap,
+}: CardholderTapModalProps) {
+  const [statusText, setStatusText] = useState("Waiting for NFC setup...");
+
+  useEffect(() => {
+    async function runScan() {
+      const messageHash = hashMessage(message);
+      let command = {
+        name: "sign",
+        keyNo: 2,
+        digest: Buffer.from(messageHash).toString("hex"),
+      };
+
+      let res;
+      try {
+        // --- request NFC command execution ---
+        res = await execHaloCmdWeb(command, {
+          statusCallback: (cause: any) => {
+            if (cause === "init") {
+              setStatusText(
+                "Please tap the tag to the back of your smartphone and hold it..."
+              );
+            } else if (cause === "retry") {
+              setStatusText(
+                "Something went wrong, please try to tap the tag again..."
+              );
+            } else if (cause === "scanned") {
+              setStatusText(
+                "Tag scanned successfully, post-processing the result..."
+              );
+            } else {
+              setStatusText(cause);
+            }
+          },
+        });
+
+        await onTap({
+          digest: res.input.digest,
+          rawSignature: res.signature.raw,
+          publicKey: res.publicKey,
+        });
+        console.log("Tapped card: ", res);
+        setStatusText("Tapped card! Process result...");
+      } catch (error) {
+        console.error(error);
+        setStatusText("Scanning failed, please try again.");
+      }
+    }
+
+    runScan();
+  }, [onTap, message]);
+
+  return (
+    <Modal>
+      <OuterContainer>
+        <InnerContainer>
+          <PrimaryFontH3 style={{ color: "var(--woodsmoke-100)" }}>
+            Place the NFC card on your phone.
+          </PrimaryFontH3>
+          <PrimaryFontBase style={{ color: "var(--woodsmoke-100)" }}>
+            {statusText}
+          </PrimaryFontBase>
+          <PrimaryFontBase style={{ color: "var(--woodsmoke-100)" }}>
+            {"If you still can't tap, check out the "}
+            <a
+              href="https://pse-team.notion.site/Card-tapping-instructions-ac5cae2f72e34155ba67d8a251b2857c?pvs=4"
+              target="_blank"
+              style={{ textDecoration: "underline" }}
+            >
+              troubleshooting guide
+            </a>
+            .
+          </PrimaryFontBase>
+        </InnerContainer>
+      </OuterContainer>
+      <img
+        src="/phone-tap.gif"
+        style={{ marginTop: "40px", marginBottom: "40px" }}
+      />
+    </Modal>
+  );
+}

--- a/components/screens/CardholderScreen.tsx
+++ b/components/screens/CardholderScreen.tsx
@@ -1,0 +1,118 @@
+import styled from "styled-components";
+import { MainHeader } from "@/components/shared/Headers";
+import Footer from "@/components/shared/Footer";
+import { TextArea } from "@/components/shared/TextArea";
+import { PrimaryLargeButton } from "@/components/shared/Buttons";
+import { CourierPrimeBase, PrimaryFontH1 } from "@/components/core";
+import { useState } from "react";
+import CardholderTapModal from "../modals/CardholderTapModal";
+
+export type SignMessageArgs = {
+  digest: string;
+  rawSignature: {
+    r: string;
+    s: string;
+    v: number;
+  };
+  publicKey: string;
+};
+
+enum CardholderDisplayState {
+  CHAT,
+  TAP,
+  SUBMITTING,
+}
+
+export default function CardholderScreen() {
+  const [message, setMessage] = useState("");
+  const [displayState, setDisplayState] = useState<CardholderDisplayState>(
+    CardholderDisplayState.CHAT
+  );
+
+  const onCardholderTap = async (args: SignMessageArgs): Promise<void> => {
+    setDisplayState(CardholderDisplayState.SUBMITTING);
+    await fetch("/api/cardholder", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        message: message,
+        signature: args.rawSignature,
+      }),
+    }).then(async (response) => {
+      setMessage("");
+      setDisplayState(CardholderDisplayState.CHAT);
+      if (response.status === 200) {
+        alert("Successfully sent chat message!");
+      } else {
+        const data = await response.json();
+        if (data.error) {
+          console.error(data.error);
+        }
+        alert("Error sending chat message.");
+      }
+    });
+  };
+
+  const onSubmit = async () => {
+    if (!message) {
+      alert("Please enter a message.");
+      return;
+    }
+
+    setDisplayState(CardholderDisplayState.TAP);
+  };
+
+  const getDisplayText = () => {
+    switch (displayState) {
+      case CardholderDisplayState.CHAT:
+        return "SEND";
+      case CardholderDisplayState.TAP:
+        return "TAP";
+      case CardholderDisplayState.SUBMITTING:
+        return "SENDING MESSAGE...";
+    }
+  };
+
+  if (displayState === CardholderDisplayState.TAP) {
+    return <CardholderTapModal message={message} onTap={onCardholderTap} />;
+  }
+
+  return (
+    <div className="flex flex-col min-h-screen">
+      <MainHeader />
+      <ChatContainer>
+        <PrimaryFontH1 style={{ color: "var(--woodsmoke-100)" }}>
+          Cardholder Chat
+        </PrimaryFontH1>
+        <CourierPrimeBase style={{ maxWidth: "90%" }}>
+          Chat pseudonymously with other Sigmoji holders! Messages will be sent
+          to the Sigmoji Telegram group. This chat is only available to Sigmoji
+          Cardholders.
+        </CourierPrimeBase>
+        <CourierPrimeBase style={{ color: "var(--woodsmoke-100)" }}>
+          When you send a chat message, you will be asked to tap your card. This
+          will generate a signature that authenticates your message.
+        </CourierPrimeBase>
+        <TextArea header="Message" value={message} setValue={setMessage} />
+        <PrimaryLargeButton onClick={onSubmit}>
+          {getDisplayText()}
+        </PrimaryLargeButton>
+      </ChatContainer>
+      <div style={{ marginTop: "auto" }}>
+        <Footer />
+      </div>
+    </div>
+  );
+}
+
+const ChatContainer = styled.div`
+  display: flex;
+  gap: 16px;
+  padding: 8px;
+  flex-direction: column;
+  text-align: center;
+  align-items: center;
+  align-self: stretch;
+`;

--- a/lib/signatureUtils.ts
+++ b/lib/signatureUtils.ts
@@ -1,4 +1,15 @@
 import { ecrecover } from "@ethereumjs/util";
+import { hashPersonalMessage } from "@ethereumjs/util";
+
+/**
+ * Hashes a message using Ethereum personal_sign.
+ * @param message - Text representation of the message to hash.
+ * @returns The hash of the message as a Uint8Array.
+ */
+export function hashMessage(message: string): Uint8Array {
+  const messageBuffer = Buffer.from(message);
+  return hashPersonalMessage(messageBuffer);
+}
 
 export function parseDERSignature(signature: string) {
   const buf = Buffer.from(signature, "hex");


### PR DESCRIPTION
Chat for Sigmoji cardholders. Cardholders can send special messages that require a signature from tapping the card with each message. These messages can be specially delivered to an audience.